### PR TITLE
Fixes JOINDIN-377 - removes word 'View' from talk(s), track(s) and comment(s) buttons in Event detail page

### DIFF
--- a/source/res/values/strings.xml
+++ b/source/res/values/strings.xml
@@ -68,14 +68,14 @@
 
     <!-- Global strings, can occur everywhere -->
     <string name="generalPleaseWait">Please wait...</string>
-    <string name="generalViewCommentSingular">View comment (%d)</string>
-    <string name="generalViewCommentPlural">View comments (%d)</string>
+    <string name="generalViewCommentSingular">Comment (%d)</string>
+    <string name="generalViewCommentPlural">Comments (%d)</string>
 
-    <string name="generalViewTrackSingular">View tracks (%d)</string>
-    <string name="generalViewTrackPlural">View tracks (%d)</string>
+    <string name="generalViewTrackSingular">Track (%d)</string>
+    <string name="generalViewTrackPlural">Tracks (%d)</string>
 
-    <string name="generalViewTalkSingular">View talk (%d)</string>
-    <string name="generalViewTalkPlural">View talks (%d)</string>
+    <string name="generalViewTalkSingular">Talk (%d)</string>
+    <string name="generalViewTalkPlural">Talks (%d)</string>
 
     <string name="generalEventTalksSingular">%d event talk</string>
     <string name="generalEventTalksPlural">%d event talks</string>


### PR DESCRIPTION
This PR removes the word "View" from src/res/values/strings.xml as follows:

generalEvent<$item>Singular (String), and 
generalEvent<$item>Plural (String) 

....where $item = Track/s, Talk/s and Comment/s

I also fixed where one occurence where $item was appearing as plural where it should have been singular.  

I wasn't able to 'Run' the application to test it as there were 5 errors in the Problems view (to do with build issues) that I didn't understand and couldn't debug (yet).  I hope this fixes the issue though.
