### PR TITLE
Fixes JOINDIN-386 - view talk button text now populated with dynamic string value, as expected

### DIFF
--- a/source/src/in/joind/EventDetail.java
+++ b/source/src/in/joind/EventDetail.java
@@ -121,9 +121,18 @@ public class EventDetail extends JIActivity implements OnClickListener {
         t = (TextView) this.findViewById(R.id.EventDetailsDescription);
         t.setText (event.optString("description"));
         Linkify.addLinks(t, Linkify.ALL);
+        
+     // Add number of talks to the correct button caption
+        Button b = (Button) this.findViewById(R.id.ButtonEventDetailsViewTalks);
+        int talkCount = event.optInt("event_talks_count");
+        if (talkCount == 1) {
+            b.setText(String.format(getString(R.string.generalViewTalkSingular), talkCount));
+        } else {
+            b.setText(String.format(getString(R.string.generalViewTalkPlural), talkCount));
+        }
 
         // Add number of comments to the correct button caption
-        Button b = (Button) this.findViewById(R.id.ButtonEventDetailsViewComments);
+        b = (Button) this.findViewById(R.id.ButtonEventDetailsViewComments);
         int commentCount = event.optInt("event_comments_count");
         if (commentCount == 1) {
             b.setText(String.format(getString(R.string.generalViewCommentSingular), commentCount));


### PR DESCRIPTION
Populate view talks button on event detail page with src/res/values/strings.xml::generalViewTalkSingular or generalViewTalkPlural string value, as appropriate (instead of default text value hard-coded into src/res/layout/eventdetail.xml
