### PR TITLE
Close the output stream before closing connection

### DIFF
--- a/source/src/in/joind/JIRest.java
+++ b/source/src/in/joind/JIRest.java
@@ -160,6 +160,7 @@ class JIRest {
             if (content != null) {
                 OutputStream outputStream = new BufferedOutputStream(connection.getOutputStream());
                 outputStream.write(content.toString().getBytes(Charset.forName("UTF-8")));
+                outputStream.close();
             }
 
             // Get response


### PR DESCRIPTION
This was causing "Unexpected end of stream" errors when trying to execute any POST requests (such as posting comments).
