### PR TITLE
Allow talk row height to be variable.

### DIFF
--- a/source/res/layout/talkrow.xml
+++ b/source/res/layout/talkrow.xml
@@ -2,7 +2,7 @@
 <!-- A single row with talk information. Used in the listviews -->
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
               android:layout_width="match_parent"
-              android:layout_height="?android:attr/listPreferredItemHeight"
+              android:layout_height="wrap_content"
               android:orientation="vertical"
               android:descendantFocusability="blocksDescendants">
 


### PR DESCRIPTION
In some cases the fixed row height was causing the talk time & track name to be obscured.