### PR TITLE
JOINDIN-669 - Starred talks bug

### DIFF
--- a/source/res/values/strings.xml
+++ b/source/res/values/strings.xml
@@ -131,7 +131,6 @@
 
     <string name="generalSuccessStarred">Successfully starred</string>
     <string name="generalSuccessUnstarred">Successfully unstarred</string>
-    <string name="generalStarringError">Starring error: %s</string>
     <string name="generalCouldntUpdateStarredStatus">Couldn't update talk starred status</string>
 
     <string name="generalAboutTitle">About…</string>

--- a/source/res/values/strings.xml
+++ b/source/res/values/strings.xml
@@ -132,6 +132,7 @@
     <string name="generalSuccessStarred">Successfully starred</string>
     <string name="generalSuccessUnstarred">Successfully unstarred</string>
     <string name="generalStarringError">Starring error: %s</string>
+    <string name="generalCouldntUpdateStarredStatus">Couldn't update talk starred status</string>
 
     <string name="generalAboutTitle">About…</string>
     <string name="generalAboutButtonCaption">Close</string>

--- a/source/res/values/strings.xml
+++ b/source/res/values/strings.xml
@@ -131,7 +131,7 @@
 
     <string name="generalSuccessStarred">Successfully starred</string>
     <string name="generalSuccessUnstarred">Successfully unstarred</string>
-    <string name="generalCouldntUpdateStarredStatus">Couldn't update talk starred status</string>
+    <string name="generalCouldntUpdateStarredStatus">Couldn\'t update talk starred status</string>
 
     <string name="generalAboutTitle">About…</string>
     <string name="generalAboutButtonCaption">Close</string>

--- a/source/src/in/joind/DataHelper.java
+++ b/source/src/in/joind/DataHelper.java
@@ -28,7 +28,7 @@ public final class DataHelper {
     private static DataHelper DHInstance = null;
 
     private static final String DATABASE_NAME = "joindin.db";
-    private static final int DATABASE_VERSION = 13;  // Increasing this version number will result in automatic call to onUpgrade()
+    private static final int DATABASE_VERSION = 14;  // Increasing this version number will result in automatic call to onUpgrade()
 
     public static final int ORDER_DATE_ASC = 1;
     public static final int ORDER_DATE_DESC = 2;
@@ -332,7 +332,7 @@ public final class DataHelper {
         public void onCreate(SQLiteDatabase db) {
             db.execSQL("CREATE TABLE [events]    ([event_uri] VARCHAR COLLATE NOCASE, [event_title] VARCHAR COLLATE NOCASE, [event_start] INTEGER, [json] VARCHAR)");
             db.execSQL("CREATE TABLE [event_types] ([event_id] INTEGER, [event_type] VARCHAR COLLATE NOCASE)");
-            db.execSQL("CREATE TABLE [talks]     ([event_id] INTEGER, [uri] VARCHAR, [track_id] INTEGER, [json] VARCHAR)");
+            db.execSQL("CREATE TABLE [talks]     ([event_id] INTEGER, [uri] VARCHAR, [track_id] INTEGER, [starred] INTEGER DEFAULT 0, [json] VARCHAR)");
             db.execSQL("CREATE TABLE [tracks]     ([event_id] INTEGER, [uri] VARCHAR, [json] VARCHAR)");
             db.execSQL("CREATE TABLE [ecomments] ([event_id] INTEGER, [json] VARCHAR)");
             db.execSQL("CREATE TABLE [tcomments] ([talk_id] INTEGER, [json] VARCHAR)");
@@ -344,6 +344,7 @@ public final class DataHelper {
             db.execSQL("DROP TABLE IF EXISTS events");
             db.execSQL("DROP TABLE IF EXISTS event_types");
             db.execSQL("DROP TABLE IF EXISTS talks");
+            db.execSQL("DROP TABLE IF EXISTS tracks");
             db.execSQL("DROP TABLE IF EXISTS ecomments");
             db.execSQL("DROP TABLE IF EXISTS tcomments");
 

--- a/source/src/in/joind/DataHelper.java
+++ b/source/src/in/joind/DataHelper.java
@@ -185,6 +185,19 @@ public final class DataHelper {
     }
 
     /**
+     * Set a talk's starred value
+     *
+     * @param talkURI
+     * @param isStarred
+     * @return
+     */
+    public void markTalkStarred(String talkURI, boolean isStarred) {
+        ContentValues values = new ContentValues();
+        values.put("starred", isStarred ? 1 : 0);
+        db.update("talks", values, "uri=?", new String[]{talkURI});
+    }
+
+    /**
      * Remove the specified type from the event.
      *
      * @param event_type Event type.

--- a/source/src/in/joind/TalkDetail.java
+++ b/source/src/in/joind/TalkDetail.java
@@ -273,7 +273,7 @@ public class TalkDetail extends JIActivity implements OnClickListener {
                 initialState ? JIRest.METHOD_POST : JIRest.METHOD_DELETE);
 
         if (error != JIRest.OK) {
-            return String.format(getString(R.string.generalStarringError), rest.getError());
+            return getString(R.string.generalCouldntUpdateStarredStatus);
         }
 
         // Everything went as expected

--- a/source/src/in/joind/TalkDetail.java
+++ b/source/src/in/joind/TalkDetail.java
@@ -5,6 +5,7 @@ package in.joind;
  */
 
 
+import android.content.Context;
 import android.content.Intent;
 import android.os.Bundle;
 import android.support.v7.app.ActionBar;
@@ -233,18 +234,35 @@ public class TalkDetail extends JIActivity implements OnClickListener {
     protected void markTalkStarred(final boolean isStarred) {
         updateStarredIcon(isStarred);
 
+        final Context context = this;
         new Thread() {
             public void run() {
                 displayProgressBarCircular(true);
 
-                final String result = doStarTalk(isStarred);
+                String talkURI = TalkDetail.this.talkJSON.optString("uri");
+                boolean result = doStarTalk(isStarred);
+                if (result) {
+                    DataHelper.getInstance().markTalkStarred(talkURI, isStarred);
 
-                runOnUiThread(new Runnable() {
-                    public void run() {
-                        Toast toast = Toast.makeText(getApplicationContext(), result, Toast.LENGTH_LONG);
-                        toast.show();
-                    }
-                });
+                    runOnUiThread(new Runnable() {
+                        public void run() {
+                            String toastMessage = context.getString(R.string.generalSuccessStarred);
+                            if (!isStarred) {
+                                toastMessage = context.getString(R.string.generalSuccessUnstarred);
+                            }
+                            Toast toast = Toast.makeText(getApplicationContext(), toastMessage, Toast.LENGTH_LONG);
+                            toast.show();
+                        }
+                    });
+                } else {
+                    runOnUiThread(new Runnable() {
+                        @Override
+                        public void run() {
+                            updateStarredIcon(!isStarred);
+                            Toast.makeText(context, context.getString(R.string.generalCouldntUpdateStarredStatus), Toast.LENGTH_SHORT).show();
+                        }
+                    });
+                }
 
                 displayProgressBarCircular(false);
             }
@@ -265,22 +283,12 @@ public class TalkDetail extends JIActivity implements OnClickListener {
      * Post/delete the starred status from this talk
      *
      * @param initialState Initial state.
-     * @return Return message.
+     * @return
      */
-    private String doStarTalk(boolean initialState) {
+    private boolean doStarTalk(boolean initialState) {
         JIRest rest = new JIRest(this);
-        int error = rest.requestToFullURI(this.talkJSON.optString("starred_uri"), null,
-                initialState ? JIRest.METHOD_POST : JIRest.METHOD_DELETE);
+        int error = rest.requestToFullURI(this.talkJSON.optString("starred_uri"), null, initialState ? JIRest.METHOD_POST : JIRest.METHOD_DELETE);
 
-        if (error != JIRest.OK) {
-            return getString(R.string.generalCouldntUpdateStarredStatus);
-        }
-
-        // Everything went as expected
-        if (initialState) {
-            return getString(R.string.generalSuccessStarred);
-        } else {
-            return getString(R.string.generalSuccessUnstarred);
-        }
+        return error == JIRest.OK;
     }
 }


### PR DESCRIPTION
https://joindin.jira.com/browse/JOINDIN-669

Fixes the starred status not being saved locally upon starring/unstarring successfully with the remote API. This was causing the starred icon to always be set to "unstarred". We now save the starred status change if the remote API call is successful, otherwise we notify the user.

This is fixed both on the Talk listing and also on the Talk Detail view.