### PR TITLE
Fix event start date storage, drop tracks on upgrade.

### DIFF
--- a/source/src/in/joind/DataHelper.java
+++ b/source/src/in/joind/DataHelper.java
@@ -28,7 +28,7 @@ public final class DataHelper {
     private static DataHelper DHInstance = null;
 
     private static final String DATABASE_NAME = "joindin.db";
-    private static final int DATABASE_VERSION = 13;  // Increasing this version number will result in automatic call to onUpgrade()
+    private static final int DATABASE_VERSION = 14;  // Increasing this version number will result in automatic call to onUpgrade()
 
     public static final int ORDER_DATE_ASC = 1;
     public static final int ORDER_DATE_DESC = 2;
@@ -330,7 +330,7 @@ public final class DataHelper {
 
         // Create new database (if needed)
         public void onCreate(SQLiteDatabase db) {
-            db.execSQL("CREATE TABLE [events]    ([event_uri] VARCHAR COLLATE NOCASE, [event_title] VARCHAR COLLATE NOCASE, [event_start] INTEGER, [json] VARCHAR)");
+            db.execSQL("CREATE TABLE [events]    ([event_uri] VARCHAR COLLATE NOCASE, [event_title] VARCHAR COLLATE NOCASE, [event_start] VARCHAR COLLATE NOCASE, [json] VARCHAR)");
             db.execSQL("CREATE TABLE [event_types] ([event_id] INTEGER, [event_type] VARCHAR COLLATE NOCASE)");
             db.execSQL("CREATE TABLE [talks]     ([event_id] INTEGER, [uri] VARCHAR, [track_id] INTEGER, [json] VARCHAR)");
             db.execSQL("CREATE TABLE [tracks]     ([event_id] INTEGER, [uri] VARCHAR, [json] VARCHAR)");
@@ -344,6 +344,7 @@ public final class DataHelper {
             db.execSQL("DROP TABLE IF EXISTS events");
             db.execSQL("DROP TABLE IF EXISTS event_types");
             db.execSQL("DROP TABLE IF EXISTS talks");
+            db.execSQL("DROP TABLE IF EXISTS tracks");
             db.execSQL("DROP TABLE IF EXISTS ecomments");
             db.execSQL("DROP TABLE IF EXISTS tcomments");
 


### PR DESCRIPTION
The event start date column was listed as an integer, from the old v1 days. This is now a string, so the column definition has been updated accordingly.

Also added the missing `DROP TABLE` statement for the tracks table upon upgrade.